### PR TITLE
feat: add AESTETIK backend to identify_spatial_domains

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,7 +17,7 @@ authors:
 abstract: >-
   ChatSpatial is a schema-enforced orchestration framework for spatial transcriptomics
   in which the LLM selects versioned tools and parameters rather than generating
-  executable code. Built on the Model Context Protocol (MCP), it exposes 65 methods
+  executable code. Built on the Model Context Protocol (MCP), it exposes 66 methods
   across 15 analytical categories from fragmented Python and R ecosystems through 20
   high-level tools with parameter constraints encoded in auditable schemas, enabling
   researchers to execute complex multi-tool workflows through natural language.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ChatSpatial replaces ad-hoc LLM code generation with **schema-enforced orchestration**. Instead of generating arbitrary scripts, the LLM selects tools and parameters from a curated registry, making spatial transcriptomics workflows more reproducible across sessions and clients.
 
-ChatSpatial exposes **20 schema-validated MCP tools** that orchestrate **65 spatial transcriptomics methods** across **15 analytical categories**. The tools are the stable natural-language interface; the methods are the analysis backends selected through tool parameters.
+ChatSpatial exposes **20 schema-validated MCP tools** that orchestrate **66 spatial transcriptomics methods** across **15 analytical categories**. The tools are the stable natural-language interface; the methods are the analysis backends selected through tool parameters.
 
 The server implements MCP `2026-07-28` through the official Python SDK v2 and
 continues to serve `2025-11-25` clients through SDK-managed protocol negotiation.
@@ -58,13 +58,13 @@ If you use Docker, mount host data to `/data` and prompt with the container path
 
 ## Capabilities
 
-Current coverage includes 65 methods across 15 analytical categories, exposed through 20 MCP tools. Supports 10x Visium, Xenium, Slide-seq v2, MERFISH, seqFISH.
+Current coverage includes 66 methods across 15 analytical categories, exposed through 20 MCP tools. Supports 10x Visium, Xenium, Slide-seq v2, MERFISH, seqFISH.
 
 | Category | Example methods |
 |----------|---------|
 | **Data Loading & Preprocessing** | Scanpy I/O, QC, Normalization, HVG, PCA, Neighbors |
 | **Visualization** | Spatial plots, Embedding plots, Gene expression overlays |
-| **Spatial Domain Identification** | SpaGCN, STAGATE, GraphST, BANKSY, Leiden, Louvain |
+| **Spatial Domain Identification** | SpaGCN, STAGATE, GraphST, BANKSY, AESTETIK, Leiden, Louvain |
 | **Deconvolution** | FlashDeconv, Cell2location, RCTD, DestVI, Stereoscope, SPOTlight, Tangram, CARD |
 | **Cell-Cell Communication** | LIANA+, CellPhoneDB, CellChat (`cellchat_r`), FastCCC |
 | **Cell Type Annotation** | Tangram, scANVI, CellAssign, mLLMCelltype, scType, SingleR |

--- a/chatspatial/__init__.py
+++ b/chatspatial/__init__.py
@@ -2,7 +2,7 @@
 ChatSpatial
 
 Schema-enforced orchestration framework for spatial transcriptomics analysis.
-Integrates 65 methods across 15 analytical categories via Model Context Protocol.
+Integrates 66 methods across 15 analytical categories via Model Context Protocol.
 """
 
 import tomllib

--- a/chatspatial/models/data.py
+++ b/chatspatial/models/data.py
@@ -1276,11 +1276,11 @@ class DeconvolutionParameters(StrictParameters):
 class SpatialDomainParameters(StrictParameters):
     """Spatial domain identification parameters model"""
 
-    method: Literal["spagcn", "leiden", "louvain", "stagate", "graphst", "banksy"] = (
-        Field(
-            default="spagcn",
-            description="'spagcn' uses histology. 'banksy' uses spatial feature augmentation. 'stagate'/'graphst' use deep learning.",
-        )
+    method: Literal[
+        "spagcn", "leiden", "louvain", "stagate", "graphst", "banksy", "aestetik"
+    ] = Field(
+        default="spagcn",
+        description="'spagcn' uses histology. 'banksy' uses spatial feature augmentation. 'stagate'/'graphst' use deep learning. 'aestetik' fuses precomputed expression and morphology embeddings.",
     )
     n_domains: int = Field(
         default=7, gt=0, le=50, description="Number of spatial domains to identify."
@@ -1366,8 +1366,47 @@ class SpatialDomainParameters(StrictParameters):
         default=0.5, gt=0.0, description="Leiden resolution for BANKSY clustering."
     )
 
+    # AESTETIK specific parameters
+    aestetik_transcriptomics_key: str = Field(
+        default="X_pca",
+        description="obsm key holding the precomputed expression embedding (AESTETIK only).",
+    )
+    aestetik_morphology_key: str = Field(
+        default="X_pca_morphology",
+        description="obsm key holding the precomputed per-spot morphology embedding (AESTETIK only).",
+    )
+    aestetik_morphology_weight: float = Field(
+        default=1.5,
+        ge=0.0,
+        description="Morphology weight in the AESTETIK joint loss.",
+    )
+    aestetik_window_size: int = Field(
+        default=3,
+        gt=0,
+        le=15,
+        description="Odd side length of the AESTETIK neighborhood grid.",
+    )
+    aestetik_clustering_method: Literal["bgm", "kmeans", "louvain", "leiden"] = Field(
+        default="kmeans",
+        description="Clustering applied to AESTETIK embeddings. 'kmeans'/'bgm' use n_domains; 'leiden'/'louvain' use resolution.",
+    )
+    aestetik_latent_dim: int = Field(
+        default=16, gt=0, le=512, description="AESTETIK latent embedding dimension."
+    )
+    aestetik_max_epochs: int = Field(
+        default=100, gt=0, le=10000, description="AESTETIK training epochs."
+    )
+    aestetik_random_seed: int = 2023
+
     # Simple timeout configuration
     timeout: Optional[int] = None  # Timeout in seconds (default: 600)
+
+    @field_validator("aestetik_window_size")
+    @classmethod
+    def validate_aestetik_window_size(cls, v: int) -> int:
+        if v % 2 == 0:
+            raise ValueError("aestetik_window_size must be an odd integer")
+        return v
 
 
 class SpatialVariableGenesParameters(StrictParameters):

--- a/chatspatial/models/data.py
+++ b/chatspatial/models/data.py
@@ -1378,6 +1378,7 @@ class SpatialDomainParameters(StrictParameters):
     aestetik_morphology_weight: float = Field(
         default=1.5,
         ge=0.0,
+        le=3.0,
         description="Morphology weight in the AESTETIK joint loss.",
     )
     aestetik_window_size: int = Field(

--- a/chatspatial/spatial_mcp_adapter.py
+++ b/chatspatial/spatial_mcp_adapter.py
@@ -619,7 +619,7 @@ def create_spatial_mcp_server(
         Tuple of (MCPServer instance, SpatialMCPAdapter instance)
     """
     # Server instructions for LLM guidance on tool usage
-    instructions = """ChatSpatial provides spatial transcriptomics analysis through 65 methods across 15 analytical categories.
+    instructions = """ChatSpatial provides spatial transcriptomics analysis through 66 methods across 15 analytical categories.
 
 CORE WORKFLOW PATTERN:
 1. Always start with load_data() to import spatial transcriptomics data
@@ -658,7 +658,7 @@ For multi-step analyses, preserve data_id across operations to maintain analysis
         title="ChatSpatial",
         description=(
             "Schema-enforced spatial transcriptomics analysis with 20 tools "
-            "covering 65 methods across 15 analytical categories."
+            "covering 66 methods across 15 analytical categories."
         ),
         instructions=instructions,
         website_url="https://github.com/cafferychen777/ChatSpatial",

--- a/chatspatial/tools/spatial_domains.py
+++ b/chatspatial/tools/spatial_domains.py
@@ -9,6 +9,8 @@ function, which handles data preparation and dispatches to the selected method.
 """
 
 import logging
+import sys
+import tempfile
 from collections import Counter
 from typing import TYPE_CHECKING, Any
 
@@ -1193,6 +1195,8 @@ async def _identify_domains_banksy(
 # write happens before its own grid construction reads the transcriptomics
 # key, so the combined key must never alias the transcriptomics key.
 _AESTETIK_COMBINED_OBSM_KEY = "X_aestetik_combined"
+_AESTETIK_TRANSCRIPTOMICS_OBSM_KEY = "X_pca_transcriptomics"
+_AESTETIK_MORPHOLOGY_OBSM_KEY = "X_pca_morphology"
 
 
 def _require_aestetik_representation(
@@ -1217,13 +1221,93 @@ def _require_aestetik_representation(
             f"column, found shape {matrix.shape}. {guidance}"
         )
 
-    if not np.all(np.isfinite(matrix)):
+    try:
+        is_finite = np.all(np.isfinite(matrix))
+    except TypeError as exc:
+        raise DataNotFoundError(
+            f"adata.obsm['{obsm_key}'] is not a numeric {modality} embedding. "
+            f"{guidance}"
+        ) from exc
+
+    if not is_finite:
         raise DataNotFoundError(
             f"adata.obsm['{obsm_key}'] contains NaN or infinite values and "
             f"cannot be used as the {modality} embedding. {guidance}"
         )
 
     return matrix
+
+
+def _managed_aestetik_estimator(
+    estimator_cls: type,
+    trainer_root: str,
+    **kwargs: Any,
+) -> Any:
+    """Create an AESTETIK estimator whose Lightning trainer writes no artifacts.
+
+    AESTETIK 0.3.x constructs its trainer through a protected factory without
+    exposing Lightning configuration. A request-local subclass is safer than a
+    process-wide working-directory or monkeypatch guard: concurrent MCP calls
+    cannot redirect one another's files or trainer configuration.
+    """
+
+    class _ManagedAESTETIK(estimator_cls):
+        def _build_trainer(self) -> tuple[Any, list[Any]]:
+            trainer, callbacks = super()._build_trainer()
+            logger_connector = getattr(trainer, "_logger_connector", None)
+            if logger_connector is None or not hasattr(
+                logger_connector, "configure_logger"
+            ):
+                raise DependencyError(
+                    "The installed AESTETIK/Lightning combination does not "
+                    "support artifact-free server execution. Install the "
+                    "supported dependency family with "
+                    "pip install 'chatspatial[aestetik]'."
+                )
+            trainer._default_root_dir = trainer_root
+            logger_connector.configure_logger(False)
+            return trainer, callbacks
+
+    return _ManagedAESTETIK(**kwargs)
+
+
+def _install_aestetik_compatibility_inputs(
+    adata: Any,
+    transcriptomics_key: str,
+    morphology_key: str,
+) -> dict[str, Any]:
+    """Install AESTETIK 0.3.x canonical aliases and return overwritten values.
+
+    AESTETIK exposes configurable input keys, but its training dataset still
+    reads cluster labels derived from the two historical key names. The aliases
+    live only on ChatSpatial's request-local working copy and are restored after
+    fitting, so neither user data nor concurrent requests are affected.
+    """
+    previous: dict[str, Any] = {}
+    aliases = {
+        _AESTETIK_TRANSCRIPTOMICS_OBSM_KEY: transcriptomics_key,
+        _AESTETIK_MORPHOLOGY_OBSM_KEY: morphology_key,
+    }
+
+    for alias, source in aliases.items():
+        if alias in adata.obsm and alias != source:
+            previous[alias] = adata.obsm[alias]
+        elif alias not in adata.obsm:
+            previous[alias] = None
+        adata.obsm[alias] = adata.obsm[source]
+
+    return previous
+
+
+def _restore_aestetik_compatibility_inputs(
+    adata: Any, previous: dict[str, Any]
+) -> None:
+    """Restore canonical AESTETIK aliases after request-local fitting."""
+    for key, value in previous.items():
+        if value is None:
+            del adata.obsm[key]
+        else:
+            adata.obsm[key] = value
 
 
 def _apply_aestetik_lattice_coordinates(adata: Any) -> str:
@@ -1291,6 +1375,12 @@ async def _identify_domains_aestetik(
     import asyncio
     import concurrent.futures
 
+    if sys.version_info >= (3, 14):
+        raise DependencyError(
+            "AESTETIK does not support Python 3.14. Run ChatSpatial with "
+            "Python 3.11, 3.12, or 3.13 to use method='aestetik'."
+        )
+
     aestetik = require(
         "aestetik", ctx, feature="AESTETIK spatial domain identification"
     )
@@ -1330,28 +1420,45 @@ async def _identify_domains_aestetik(
         else:
             n_cluster = params.resolution
 
-        model = estimator_cls(
-            n_cluster=n_cluster,
-            morphology_weight=params.aestetik_morphology_weight,
-            window_size=params.aestetik_window_size,
-            clustering_method=params.aestetik_clustering_method,
-            latent_dim=params.aestetik_latent_dim,
-            max_epochs=params.aestetik_max_epochs,
-            random_state=params.aestetik_random_seed,
-            refine_cluster=False,
-            used_obsm_transcriptomics=params.aestetik_transcriptomics_key,
-            used_obsm_morphology=params.aestetik_morphology_key,
-            used_obsm_combined=_AESTETIK_COMBINED_OBSM_KEY,
-        )
-
         loop = asyncio.get_running_loop()
         timeout_seconds = params.timeout if params.timeout is not None else 600
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
 
             def _fit_aestetik():
-                with suppress_output():
-                    return model.fit(adata_aestetik)
+                previous_inputs = _install_aestetik_compatibility_inputs(
+                    adata_aestetik,
+                    params.aestetik_transcriptomics_key,
+                    params.aestetik_morphology_key,
+                )
+                try:
+                    with tempfile.TemporaryDirectory(
+                        prefix="chatspatial-aestetik-"
+                    ) as trainer_root:
+                        model = _managed_aestetik_estimator(
+                            estimator_cls,
+                            trainer_root,
+                            n_cluster=n_cluster,
+                            morphology_weight=params.aestetik_morphology_weight,
+                            window_size=params.aestetik_window_size,
+                            clustering_method=params.aestetik_clustering_method,
+                            latent_dim=params.aestetik_latent_dim,
+                            max_epochs=params.aestetik_max_epochs,
+                            random_state=params.aestetik_random_seed,
+                            refine_cluster=False,
+                            validation_split=0.0,
+                            used_obsm_transcriptomics=(
+                                _AESTETIK_TRANSCRIPTOMICS_OBSM_KEY
+                            ),
+                            used_obsm_morphology=_AESTETIK_MORPHOLOGY_OBSM_KEY,
+                            used_obsm_combined=_AESTETIK_COMBINED_OBSM_KEY,
+                        )
+                        with suppress_output():
+                            return model.fit(adata_aestetik)
+                finally:
+                    _restore_aestetik_compatibility_inputs(
+                        adata_aestetik, previous_inputs
+                    )
 
             fitted = await asyncio.wait_for(
                 loop.run_in_executor(executor, _fit_aestetik),
@@ -1368,11 +1475,19 @@ async def _identify_domains_aestetik(
                 "AESTETIK returned an embedding with unexpected shape "
                 f"{embedding.shape} for {adata_aestetik.n_obs} spots."
             )
+        try:
+            embedding_is_finite = np.all(np.isfinite(embedding))
+        except TypeError as exc:
+            raise ProcessingError("AESTETIK returned a non-numeric embedding.") from exc
+        if not embedding_is_finite:
+            raise ProcessingError("AESTETIK returned a non-finite embedding.")
         if labels.shape[0] != adata_aestetik.n_obs:
             raise ProcessingError(
                 f"AESTETIK returned {labels.shape[0]} cluster labels for "
                 f"{adata_aestetik.n_obs} spots."
             )
+        if np.any(pd.isna(labels)):
+            raise ProcessingError("AESTETIK returned missing cluster labels.")
 
         embeddings_key = "X_aestetik"
         adata.obsm[embeddings_key] = embedding

--- a/chatspatial/tools/spatial_domains.py
+++ b/chatspatial/tools/spatial_domains.py
@@ -31,6 +31,7 @@ from ..utils.exceptions import (
     ChatSpatialError,
     DataError,
     DataNotFoundError,
+    DependencyError,
     ParameterError,
     ProcessingError,
 )
@@ -225,9 +226,15 @@ async def identify_spatial_domains(
             domain_labels, embeddings_key, statistics = await _identify_domains_banksy(
                 adata_subset, params, ctx
             )
+        elif params.method == "aestetik":
+            (
+                domain_labels,
+                embeddings_key,
+                statistics,
+            ) = await _identify_domains_aestetik(adata_subset, params, ctx)
         else:
             raise ParameterError(
-                f"Unsupported method: {params.method}. Available methods: spagcn, leiden, louvain, stagate, graphst, banksy"
+                f"Unsupported method: {params.method}. Available methods: spagcn, leiden, louvain, stagate, graphst, banksy, aestetik"
             )
 
         # Build the published result on a fresh source copy. Backend workspaces
@@ -1180,3 +1187,218 @@ async def _identify_domains_banksy(
         raise
     except Exception as e:
         raise ProcessingError(f"BANKSY execution failed: {e}") from e
+
+
+# AESTETIK concatenates the two modalities into ``used_obsm_combined``. That
+# write happens before its own grid construction reads the transcriptomics
+# key, so the combined key must never alias the transcriptomics key.
+_AESTETIK_COMBINED_OBSM_KEY = "X_aestetik_combined"
+
+
+def _require_aestetik_representation(
+    adata: Any, obsm_key: str, modality: str, guidance: str
+) -> np.ndarray:
+    """Return a validated 2D representation from ``adata.obsm``."""
+    available = sorted(adata.obsm.keys())
+
+    if obsm_key not in adata.obsm:
+        raise DataNotFoundError(
+            f"AESTETIK requires a precomputed {modality} embedding in "
+            f"adata.obsm['{obsm_key}'], which is not present. {guidance} "
+            f"Available obsm keys: {available}."
+        )
+
+    matrix = np.asarray(adata.obsm[obsm_key])
+
+    if matrix.ndim != 2 or matrix.shape[0] != adata.n_obs or matrix.shape[1] < 1:
+        raise DataNotFoundError(
+            f"adata.obsm['{obsm_key}'] is not a usable {modality} embedding: "
+            f"expected a 2D array with {adata.n_obs} rows and at least one "
+            f"column, found shape {matrix.shape}. {guidance}"
+        )
+
+    if not np.all(np.isfinite(matrix)):
+        raise DataNotFoundError(
+            f"adata.obsm['{obsm_key}'] contains NaN or infinite values and "
+            f"cannot be used as the {modality} embedding. {guidance}"
+        )
+
+    return matrix
+
+
+def _apply_aestetik_lattice_coordinates(adata: Any) -> str:
+    """Populate ``x_array``/``y_array`` on the working copy and report the source.
+
+    AESTETIK matches grid neighbours at an exact integer offset, so pixel
+    coordinates are never an acceptable substitute for the array lattice.
+    """
+    if "x_array" in adata.obs.columns and "y_array" in adata.obs.columns:
+        source_columns = ("x_array", "y_array")
+    elif "array_row" in adata.obs.columns and "array_col" in adata.obs.columns:
+        source_columns = ("array_row", "array_col")
+    else:
+        raise DataNotFoundError(
+            "AESTETIK requires discrete lattice coordinates in adata.obs, as "
+            "either 'x_array'/'y_array' or the Visium 'array_row'/'array_col' "
+            "columns. Neither pair is present. Pixel coordinates in "
+            "obsm['spatial'] cannot be substituted: AESTETIK only accepts grid "
+            "neighbours at an exact integer offset, so pixel coordinates would "
+            "yield an empty neighborhood for every spot. Reload the dataset "
+            "from its Space Ranger output, or add the lattice columns before "
+            "running this method. Available obs columns: "
+            f"{sorted(adata.obs.columns)}."
+        )
+
+    coordinates = []
+    for column in source_columns:
+        values = pd.to_numeric(adata.obs[column], errors="coerce").to_numpy(dtype=float)
+        if not np.all(np.isfinite(values)):
+            raise DataNotFoundError(
+                f"adata.obs['{column}'] contains non-numeric, NaN, or infinite "
+                "values and cannot be used as an AESTETIK lattice coordinate."
+            )
+        if not np.all(np.equal(np.mod(values, 1), 0)):
+            raise DataNotFoundError(
+                f"adata.obs['{column}'] holds non-integer values. AESTETIK "
+                "matches grid neighbours at an exact integer offset and cannot "
+                "use continuous coordinates."
+            )
+        coordinates.append(values)
+
+    adata.obs["x_array"] = coordinates[0]
+    adata.obs["y_array"] = coordinates[1]
+
+    return "/".join(source_columns)
+
+
+async def _identify_domains_aestetik(
+    adata: Any, params: SpatialDomainParameters, ctx: "ToolContext"
+) -> tuple:
+    """
+    Identifies spatial domains using the AESTETIK algorithm.
+
+    AESTETIK is a convolutional autoencoder that learns a representation per
+    spot from three inputs: a precomputed transcriptomics embedding, a
+    precomputed per-spot morphology embedding, and the spatial neighborhood
+    grid around the spot. The learned representations are then clustered to
+    define spatial domains. This method requires the `aestetik` package.
+
+    Morphology features are consumed, not produced: ChatSpatial does not
+    extract them from tissue images, so ``aestetik_morphology_key`` must
+    already be present in the dataset. Cluster refinement is left to the
+    shared ``refine_domains`` stage so smoothing is applied exactly once.
+    """
+    import asyncio
+    import concurrent.futures
+
+    aestetik = require(
+        "aestetik", ctx, feature="AESTETIK spatial domain identification"
+    )
+
+    estimator_cls = getattr(aestetik, "AESTETIK", None)
+    if estimator_cls is None:
+        raise DependencyError(
+            "The installed aestetik package does not expose the AESTETIK "
+            "estimator. Install a release that provides the fit/predict API: "
+            "pip install 'chatspatial[aestetik]'"
+        )
+
+    try:
+        adata_aestetik = adata
+
+        _require_aestetik_representation(
+            adata_aestetik,
+            params.aestetik_transcriptomics_key,
+            "transcriptomics",
+            "Run compute_embeddings first, or point "
+            "aestetik_transcriptomics_key at an existing representation.",
+        )
+        _require_aestetik_representation(
+            adata_aestetik,
+            params.aestetik_morphology_key,
+            "morphology",
+            "ChatSpatial does not extract morphology features from tissue "
+            "images. Add the embedding to the dataset, or point "
+            "aestetik_morphology_key at an existing representation.",
+        )
+
+        lattice_source = _apply_aestetik_lattice_coordinates(adata_aestetik)
+
+        # kmeans/bgm take a cluster count; leiden/louvain take a resolution.
+        if params.aestetik_clustering_method in ("kmeans", "bgm"):
+            n_cluster: float = params.n_domains
+        else:
+            n_cluster = params.resolution
+
+        model = estimator_cls(
+            n_cluster=n_cluster,
+            morphology_weight=params.aestetik_morphology_weight,
+            window_size=params.aestetik_window_size,
+            clustering_method=params.aestetik_clustering_method,
+            latent_dim=params.aestetik_latent_dim,
+            max_epochs=params.aestetik_max_epochs,
+            random_state=params.aestetik_random_seed,
+            refine_cluster=False,
+            used_obsm_transcriptomics=params.aestetik_transcriptomics_key,
+            used_obsm_morphology=params.aestetik_morphology_key,
+            used_obsm_combined=_AESTETIK_COMBINED_OBSM_KEY,
+        )
+
+        loop = asyncio.get_running_loop()
+        timeout_seconds = params.timeout if params.timeout is not None else 600
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+
+            def _fit_aestetik():
+                with suppress_output():
+                    return model.fit(adata_aestetik)
+
+            fitted = await asyncio.wait_for(
+                loop.run_in_executor(executor, _fit_aestetik),
+                timeout=timeout_seconds,
+            )
+
+        # Publish the embedding and labels cached by this fit. transform() is
+        # stochastic, so recomputing either one here would desynchronize them.
+        embedding = np.asarray(fitted.embedding_)
+        labels = np.asarray(fitted.labels_).ravel()
+
+        if embedding.ndim != 2 or embedding.shape[0] != adata_aestetik.n_obs:
+            raise ProcessingError(
+                "AESTETIK returned an embedding with unexpected shape "
+                f"{embedding.shape} for {adata_aestetik.n_obs} spots."
+            )
+        if labels.shape[0] != adata_aestetik.n_obs:
+            raise ProcessingError(
+                f"AESTETIK returned {labels.shape[0]} cluster labels for "
+                f"{adata_aestetik.n_obs} spots."
+            )
+
+        embeddings_key = "X_aestetik"
+        adata.obsm[embeddings_key] = embedding
+        domain_labels = pd.Series(labels, index=adata_aestetik.obs.index).astype(str)
+
+        statistics = {
+            "method": "aestetik",
+            "n_clusters": len(domain_labels.unique()),
+            "clustering_method": params.aestetik_clustering_method,
+            "morphology_weight": params.aestetik_morphology_weight,
+            "window_size": params.aestetik_window_size,
+            "latent_dim": params.aestetik_latent_dim,
+            "max_epochs": params.aestetik_max_epochs,
+            "transcriptomics_key": params.aestetik_transcriptomics_key,
+            "morphology_key": params.aestetik_morphology_key,
+            "lattice_source": lattice_source,
+            "framework": "PyTorch Lightning",
+        }
+
+        return domain_labels, embeddings_key, statistics
+
+    except asyncio.TimeoutError as e:
+        raise ProcessingError(
+            f"AESTETIK timeout after {params.timeout if params.timeout is not None else 600} seconds"
+        ) from e
+    except ChatSpatialError:
+        raise
+    except Exception as e:
+        raise ProcessingError(f"AESTETIK execution failed: {e}") from e

--- a/chatspatial/utils/dependency_manager.py
+++ b/chatspatial/utils/dependency_manager.py
@@ -188,6 +188,11 @@ DEPENDENCY_REGISTRY: dict[str, DependencyInfo] = {
         "pip install 'chatspatial[spatial-domains]'",
         "Spatial domain identification using neighborhood feature augmentation",
     ),
+    "aestetik": DependencyInfo(
+        "aestetik",
+        "pip install 'chatspatial[aestetik]'",
+        "Multi-modal autoencoder over expression, morphology, and spatial context",
+    ),
     "paste": DependencyInfo(
         "paste",
         "pip install paste-bio",

--- a/docs/advanced/methods-reference.md
+++ b/docs/advanced/methods-reference.md
@@ -6,7 +6,7 @@ behavior. MCP clients expose the full schema for method-specific advanced
 options.
 
 ChatSpatial's public interface is a set of 20 schema-validated MCP tools. Those
-tools orchestrate 65 spatial transcriptomics methods across 15 analytical
+tools orchestrate 66 spatial transcriptomics methods across 15 analytical
 categories. In this page, **tool** means the MCP entry point you or an AI client
 can call; **method** means an algorithm or analysis backend selected through a
 parameter such as `method`, `analysis_type`, `plot_type`, or `subtype`.

--- a/docs/advanced/methods-reference.md
+++ b/docs/advanced/methods-reference.md
@@ -151,9 +151,24 @@ Find tissue domains and spatial niches.
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `method` | `spagcn` | `spagcn`, `stagate`, `graphst`, `banksy`, `leiden`, `louvain` |
+| `method` | `spagcn` | `spagcn`, `stagate`, `graphst`, `banksy`, `aestetik`, `leiden`, `louvain` |
 | `n_domains` | 7 | Expected number of domains |
 | `resolution` | 0.5 | Clustering resolution |
+
+**AESTETIK** fuses a precomputed expression embedding, a precomputed per-spot morphology embedding, and the spatial neighborhood grid. It reads both representations from `adata.obsm` and does not extract morphology features from tissue images. It also needs discrete lattice coordinates in `adata.obs`, either `x_array`/`y_array` or the Visium `array_row`/`array_col` columns.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `aestetik_transcriptomics_key` | `X_pca` | obsm key with the expression embedding |
+| `aestetik_morphology_key` | `X_pca_morphology` | obsm key with the morphology embedding |
+| `aestetik_morphology_weight` | 1.5 | Morphology weight in the joint loss |
+| `aestetik_window_size` | 3 | Odd side length of the neighborhood grid |
+| `aestetik_clustering_method` | `kmeans` | `bgm`, `kmeans`, `louvain`, `leiden`. `kmeans`/`bgm` use `n_domains`; `leiden`/`louvain` use `resolution` |
+| `aestetik_latent_dim` | 16 | Latent embedding dimension |
+| `aestetik_max_epochs` | 100 | Training epochs |
+| `aestetik_random_seed` | 2023 | Random seed |
+
+Install with `pip install 'chatspatial[aestetik]'` (Python < 3.14). Method reference: [Representation learning for multi-modal spatially resolved transcriptomics data](https://doi.org/10.1093/bioinformatics/btag316), *Bioinformatics* (2026).
 
 ---
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ ChatSpatial
 Analyze your spatial data from any MCP-compatible client. No coding required.
 
 ChatSpatial exposes 20 schema-validated MCP tools. Those tools orchestrate
-65 spatial transcriptomics methods across 15 analytical categories; the tools
+66 spatial transcriptomics methods across 15 analytical categories; the tools
 are the user-facing interface, and the methods are selected through tool
 parameters.
 
@@ -16,7 +16,7 @@ parameters.
 
       <div style="margin: 2rem 0; padding: 1.5rem; background: linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 100%); border-radius: 12px; border-left: 4px solid #1565C0;">
         <p style="margin: 0; font-size: 1.1rem; color: #1e293b;">
-          <strong>20 MCP tools</strong> orchestrating 65 methods across 15 analytical categories.
+          <strong>20 MCP tools</strong> orchestrating 66 methods across 15 analytical categories.
           Supports 10x Visium, Xenium, Slide-seq, MERFISH, and more.
         </p>
       </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -225,7 +225,7 @@ spatial-domains = [
 # torchvision/lightning stack that the other spatial-domain backends do not
 # need. The environment marker keeps the 3.14 CI leg resolvable.
 aestetik = [
-    "aestetik>=0.3.1,<1.0; python_version < '3.14'",
+    "aestetik>=0.3.1,<0.4; python_version < '3.14'",
 ]
 
 # HPC acceleration (requires system PETSc/SLEPc libraries)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,6 +220,14 @@ spatial-domains = [
     "pybanksy>=1.3.5,<2.0",
 ]
 
+# AESTETIK multi-modal spatial domain identification. Kept in its own family
+# because it does not yet support Python 3.14 and because it pulls a
+# torchvision/lightning stack that the other spatial-domain backends do not
+# need. The environment marker keeps the 3.14 CI leg resolvable.
+aestetik = [
+    "aestetik>=0.3.1,<1.0; python_version < '3.14'",
+]
+
 # HPC acceleration (requires system PETSc/SLEPc libraries)
 # Install: brew install petsc slepc (macOS) or apt install petsc-dev slepc-dev (Linux)
 hpc = [

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.cafferychen777/chatspatial",
   "title": "ChatSpatial",
-  "description": "Schema-enforced spatial transcriptomics analysis with 20 tools and 65 methods via MCP",
+  "description": "Schema-enforced spatial transcriptomics analysis with 20 tools and 66 methods via MCP",
   "repository": {
     "url": "https://github.com/cafferychen777/ChatSpatial",
     "source": "github"

--- a/tests/unit/test_data_models_validation.py
+++ b/tests/unit/test_data_models_validation.py
@@ -244,6 +244,18 @@ def test_spatial_domain_includes_banksy_literal():
     assert params.method == "banksy"
 
 
+def test_spatial_domain_includes_aestetik_literal():
+    params = SpatialDomainParameters(method="aestetik")
+    assert params.method == "aestetik"
+    assert params.aestetik_transcriptomics_key == "X_pca"
+    assert params.aestetik_morphology_key == "X_pca_morphology"
+
+
+def test_spatial_domain_rejects_even_aestetik_window_size():
+    with pytest.raises(ValidationError):
+        SpatialDomainParameters(method="aestetik", aestetik_window_size=4)
+
+
 def test_spatial_variable_genes_default_is_flashs():
     params = SpatialVariableGenesParameters()
     assert params.method == "flashs"

--- a/tests/unit/test_data_models_validation.py
+++ b/tests/unit/test_data_models_validation.py
@@ -256,6 +256,11 @@ def test_spatial_domain_rejects_even_aestetik_window_size():
         SpatialDomainParameters(method="aestetik", aestetik_window_size=4)
 
 
+def test_spatial_domain_rejects_aestetik_morphology_weight_above_total_weight():
+    with pytest.raises(ValidationError):
+        SpatialDomainParameters(method="aestetik", aestetik_morphology_weight=3.1)
+
+
 def test_spatial_variable_genes_default_is_flashs():
     params = SpatialVariableGenesParameters()
     assert params.method == "flashs"

--- a/tests/unit/test_dependency_metadata_contract.py
+++ b/tests/unit/test_dependency_metadata_contract.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import tomllib
+from pathlib import Path
 
-from packaging.requirements import Requirement
 import pytest
+from packaging.requirements import Requirement
 
 from chatspatial.utils.dependency_manager import DEPENDENCY_REGISTRY
-
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -50,9 +49,7 @@ def test_dependency_families_keep_conflicting_backends_separate() -> None:
 def test_spatial_domain_extra_pins_a_coherent_graph_stack() -> None:
     """Louvain and Leiden must resolve against the same igraph generation."""
     project = _project_metadata()
-    requirements = _requirements(
-        project["optional-dependencies"]["spatial-domains"]
-    )
+    requirements = _requirements(project["optional-dependencies"]["spatial-domains"])
 
     expected_versions = {
         "spagcn": "1.2.7",
@@ -67,6 +64,21 @@ def test_spatial_domain_extra_pins_a_coherent_graph_stack() -> None:
 
     assert not requirements["igraph"][0].specifier.contains("1.0.0")
     assert not requirements["leidenalg"][0].specifier.contains("0.11.0")
+
+
+@pytest.mark.unit
+def test_aestetik_extra_is_bounded_and_excludes_python_314() -> None:
+    """AESTETIK must stay isolated from full and unsupported Python releases."""
+    project = _project_metadata()
+    extras = project["optional-dependencies"]
+    requirement = _requirements(extras["aestetik"])["aestetik"][0]
+
+    assert requirement.specifier.contains("0.3.1")
+    assert not requirement.specifier.contains("0.4.0")
+    assert requirement.marker is not None
+    assert requirement.marker.evaluate({"python_version": "3.13"})
+    assert not requirement.marker.evaluate({"python_version": "3.14"})
+    assert "aestetik" not in _requirements(extras["full"])
 
 
 @pytest.mark.unit
@@ -106,6 +118,7 @@ def test_install_guidance_uses_compatible_optional_families() -> None:
         "SpaGCN": "spatial-domains",
         "banksy": "spatial-domains",
         "louvain": "spatial-domains",
+        "aestetik": "aestetik",
     }
 
     for dependency, extra in expected_extras.items():

--- a/tests/unit/test_spatial_domains_and_genes_utils.py
+++ b/tests/unit/test_spatial_domains_and_genes_utils.py
@@ -1861,3 +1861,288 @@ async def test_identify_domains_graphst_generic_error_is_wrapped(
             SpatialDomainParameters(method="graphst"),
             DummyCtx(adata),
         )
+
+
+def _aestetik_adata(minimal_spatial_adata):
+    """Return an AnnData carrying both AESTETIK representations and a lattice."""
+    adata = minimal_spatial_adata.copy()
+    n_obs = adata.n_obs
+    adata.obsm["X_pca"] = np.tile(np.arange(4, dtype=float), (n_obs, 1))
+    adata.obsm["X_pca_morphology"] = np.tile(np.arange(3, dtype=float), (n_obs, 1))
+    adata.obs["array_row"] = np.arange(n_obs) % 6
+    adata.obs["array_col"] = np.arange(n_obs) // 6
+    return adata
+
+
+def _install_fake_aestetik(monkeypatch: pytest.MonkeyPatch, estimator_cls) -> None:
+    import sys
+    import types
+
+    module = types.ModuleType("aestetik")
+    module.AESTETIK = estimator_cls
+    monkeypatch.setitem(sys.modules, "aestetik", module)
+    monkeypatch.setattr(sd, "require", _required_dependency)
+
+
+@pytest.mark.asyncio
+async def test_identify_domains_aestetik_success_path(
+    minimal_spatial_adata, monkeypatch: pytest.MonkeyPatch
+):
+    adata = _aestetik_adata(minimal_spatial_adata)
+    recorded: dict = {}
+
+    class _FakeAestetik:
+        def __init__(self, **kwargs):
+            recorded.update(kwargs)
+
+        def fit(self, X):
+            recorded["x_array"] = X.obs["x_array"].to_numpy()
+            recorded["y_array"] = X.obs["y_array"].to_numpy()
+            self.embedding_ = np.ones((X.n_obs, 5))
+            self.labels_ = np.array(
+                ["0"] * (X.n_obs // 2) + ["1"] * (X.n_obs - X.n_obs // 2)
+            )
+            return self
+
+    _install_fake_aestetik(monkeypatch, _FakeAestetik)
+
+    labels, emb_key, stats = await sd._identify_domains_aestetik(
+        adata,
+        SpatialDomainParameters(method="aestetik", n_domains=2),
+        DummyCtx(adata),
+    )
+
+    assert len(labels) == adata.n_obs
+    assert emb_key == "X_aestetik"
+    assert adata.obsm["X_aestetik"].shape == (adata.n_obs, 5)
+    assert stats["method"] == "aestetik"
+    assert stats["n_clusters"] == 2
+    assert stats["lattice_source"] == "array_row/array_col"
+
+    # The combined key must not alias the transcriptomics key, otherwise
+    # AESTETIK overwrites its own transcriptomics input before grid building.
+    assert recorded["used_obsm_transcriptomics"] == "X_pca"
+    assert recorded["used_obsm_combined"] != recorded["used_obsm_transcriptomics"]
+    assert recorded["n_cluster"] == 2
+    assert recorded["refine_cluster"] is False
+    np.testing.assert_array_equal(recorded["x_array"], adata.obs["array_row"])
+    np.testing.assert_array_equal(recorded["y_array"], adata.obs["array_col"])
+
+
+@pytest.mark.asyncio
+async def test_identify_domains_aestetik_uses_resolution_for_graph_clustering(
+    minimal_spatial_adata, monkeypatch: pytest.MonkeyPatch
+):
+    adata = _aestetik_adata(minimal_spatial_adata)
+    recorded: dict = {}
+
+    class _FakeAestetik:
+        def __init__(self, **kwargs):
+            recorded.update(kwargs)
+
+        def fit(self, X):
+            self.embedding_ = np.ones((X.n_obs, 2))
+            self.labels_ = np.zeros(X.n_obs, dtype=int)
+            return self
+
+    _install_fake_aestetik(monkeypatch, _FakeAestetik)
+
+    await sd._identify_domains_aestetik(
+        adata,
+        SpatialDomainParameters(
+            method="aestetik", aestetik_clustering_method="leiden", resolution=0.8
+        ),
+        DummyCtx(adata),
+    )
+
+    assert recorded["n_cluster"] == 0.8
+
+
+@pytest.mark.asyncio
+async def test_identify_domains_aestetik_reuses_existing_x_array_columns(
+    minimal_spatial_adata, monkeypatch: pytest.MonkeyPatch
+):
+    adata = _aestetik_adata(minimal_spatial_adata)
+    adata.obs["x_array"] = np.arange(adata.n_obs) % 4
+    adata.obs["y_array"] = np.arange(adata.n_obs) // 4
+
+    class _FakeAestetik:
+        def __init__(self, **kwargs):
+            del kwargs
+
+        def fit(self, X):
+            self.embedding_ = np.ones((X.n_obs, 2))
+            self.labels_ = np.zeros(X.n_obs, dtype=int)
+            return self
+
+    _install_fake_aestetik(monkeypatch, _FakeAestetik)
+
+    _labels, _emb_key, stats = await sd._identify_domains_aestetik(
+        adata,
+        SpatialDomainParameters(method="aestetik"),
+        DummyCtx(adata),
+    )
+
+    assert stats["lattice_source"] == "x_array/y_array"
+    np.testing.assert_array_equal(adata.obs["x_array"], np.arange(adata.n_obs) % 4)
+
+
+@pytest.mark.asyncio
+async def test_identify_domains_aestetik_requires_morphology_embedding(
+    minimal_spatial_adata, monkeypatch: pytest.MonkeyPatch
+):
+    adata = _aestetik_adata(minimal_spatial_adata)
+    del adata.obsm["X_pca_morphology"]
+
+    class _FakeAestetik:
+        def __init__(self, **kwargs):
+            raise AssertionError("estimator must not be constructed")
+
+    _install_fake_aestetik(monkeypatch, _FakeAestetik)
+
+    with pytest.raises(DataNotFoundError, match="morphology"):
+        await sd._identify_domains_aestetik(
+            adata,
+            SpatialDomainParameters(method="aestetik"),
+            DummyCtx(adata),
+        )
+
+
+@pytest.mark.asyncio
+async def test_identify_domains_aestetik_rejects_non_finite_representation(
+    minimal_spatial_adata, monkeypatch: pytest.MonkeyPatch
+):
+    adata = _aestetik_adata(minimal_spatial_adata)
+    adata.obsm["X_pca_morphology"][0, 0] = np.nan
+
+    class _FakeAestetik:
+        def __init__(self, **kwargs):
+            raise AssertionError("estimator must not be constructed")
+
+    _install_fake_aestetik(monkeypatch, _FakeAestetik)
+
+    with pytest.raises(DataNotFoundError, match="NaN or infinite"):
+        await sd._identify_domains_aestetik(
+            adata,
+            SpatialDomainParameters(method="aestetik"),
+            DummyCtx(adata),
+        )
+
+
+@pytest.mark.asyncio
+async def test_identify_domains_aestetik_requires_lattice_coordinates(
+    minimal_spatial_adata, monkeypatch: pytest.MonkeyPatch
+):
+    adata = _aestetik_adata(minimal_spatial_adata)
+    del adata.obs["array_row"]
+    del adata.obs["array_col"]
+
+    class _FakeAestetik:
+        def __init__(self, **kwargs):
+            raise AssertionError("estimator must not be constructed")
+
+    _install_fake_aestetik(monkeypatch, _FakeAestetik)
+
+    with pytest.raises(DataNotFoundError, match="lattice coordinates"):
+        await sd._identify_domains_aestetik(
+            adata,
+            SpatialDomainParameters(method="aestetik"),
+            DummyCtx(adata),
+        )
+
+
+@pytest.mark.asyncio
+async def test_identify_domains_aestetik_rejects_non_integer_lattice(
+    minimal_spatial_adata, monkeypatch: pytest.MonkeyPatch
+):
+    adata = _aestetik_adata(minimal_spatial_adata)
+    adata.obs["array_row"] = np.linspace(0.5, 5.5, adata.n_obs)
+
+    class _FakeAestetik:
+        def __init__(self, **kwargs):
+            raise AssertionError("estimator must not be constructed")
+
+    _install_fake_aestetik(monkeypatch, _FakeAestetik)
+
+    with pytest.raises(DataNotFoundError, match="non-integer"):
+        await sd._identify_domains_aestetik(
+            adata,
+            SpatialDomainParameters(method="aestetik"),
+            DummyCtx(adata),
+        )
+
+
+@pytest.mark.asyncio
+async def test_identify_domains_aestetik_rejects_label_length_mismatch(
+    minimal_spatial_adata, monkeypatch: pytest.MonkeyPatch
+):
+    adata = _aestetik_adata(minimal_spatial_adata)
+
+    class _FakeAestetik:
+        def __init__(self, **kwargs):
+            del kwargs
+
+        def fit(self, X):
+            self.embedding_ = np.ones((X.n_obs, 2))
+            self.labels_ = np.zeros(X.n_obs - 1, dtype=int)
+            return self
+
+    _install_fake_aestetik(monkeypatch, _FakeAestetik)
+
+    with pytest.raises(ProcessingError, match="cluster labels"):
+        await sd._identify_domains_aestetik(
+            adata,
+            SpatialDomainParameters(method="aestetik"),
+            DummyCtx(adata),
+        )
+
+
+@pytest.mark.asyncio
+async def test_identify_domains_aestetik_missing_estimator_is_reported(
+    minimal_spatial_adata, monkeypatch: pytest.MonkeyPatch
+):
+    import sys
+    import types
+
+    adata = _aestetik_adata(minimal_spatial_adata)
+    monkeypatch.setitem(sys.modules, "aestetik", types.ModuleType("aestetik"))
+    monkeypatch.setattr(sd, "require", _required_dependency)
+
+    with pytest.raises(DependencyError, match="fit/predict API"):
+        await sd._identify_domains_aestetik(
+            adata,
+            SpatialDomainParameters(method="aestetik"),
+            DummyCtx(adata),
+        )
+
+
+@pytest.mark.asyncio
+async def test_identify_domains_aestetik_timeout_is_wrapped(
+    minimal_spatial_adata, monkeypatch: pytest.MonkeyPatch
+):
+    import asyncio as _asyncio
+
+    adata = _aestetik_adata(minimal_spatial_adata)
+
+    class _FakeAestetik:
+        def __init__(self, **kwargs):
+            del kwargs
+
+        def fit(self, X):
+            del X
+            return self
+
+    _install_fake_aestetik(monkeypatch, _FakeAestetik)
+
+    async def _raise_timeout(_future, timeout=None):
+        del _future, timeout
+        raise _asyncio.TimeoutError()
+
+    monkeypatch.setattr("asyncio.wait_for", _raise_timeout)
+
+    with pytest.raises(ProcessingError, match="AESTETIK timeout"):
+        await sd._identify_domains_aestetik(
+            adata,
+            SpatialDomainParameters(method="aestetik", timeout=1),
+            DummyCtx(adata),
+        )

--- a/tests/unit/test_spatial_domains_and_genes_utils.py
+++ b/tests/unit/test_spatial_domains_and_genes_utils.py
@@ -1884,6 +1884,36 @@ def _install_fake_aestetik(monkeypatch: pytest.MonkeyPatch, estimator_cls) -> No
     monkeypatch.setattr(sd, "require", _required_dependency)
 
 
+def test_managed_aestetik_estimator_disables_lightning_artifacts(tmp_path):
+    configured_loggers = []
+
+    class _LoggerConnector:
+        def configure_logger(self, logger):
+            configured_loggers.append(logger)
+
+    class _Trainer:
+        def __init__(self):
+            self._default_root_dir = "original"
+            self._logger_connector = _LoggerConnector()
+
+    class _BaseEstimator:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def _build_trainer(self):
+            return _Trainer(), ["callback"]
+
+    estimator = sd._managed_aestetik_estimator(
+        _BaseEstimator, str(tmp_path), n_cluster=3
+    )
+    trainer, callbacks = estimator._build_trainer()
+
+    assert estimator.kwargs == {"n_cluster": 3}
+    assert trainer._default_root_dir == str(tmp_path)
+    assert configured_loggers == [False]
+    assert callbacks == ["callback"]
+
+
 @pytest.mark.asyncio
 async def test_identify_domains_aestetik_success_path(
     minimal_spatial_adata, monkeypatch: pytest.MonkeyPatch
@@ -1919,14 +1949,64 @@ async def test_identify_domains_aestetik_success_path(
     assert stats["n_clusters"] == 2
     assert stats["lattice_source"] == "array_row/array_col"
 
-    # The combined key must not alias the transcriptomics key, otherwise
-    # AESTETIK overwrites its own transcriptomics input before grid building.
-    assert recorded["used_obsm_transcriptomics"] == "X_pca"
+    # AESTETIK 0.3.x exposes custom input keys but its dataset still reads
+    # clusters from these canonical aliases. ChatSpatial installs them only on
+    # the request-local working copy and removes the transcriptomics alias here.
+    assert recorded["used_obsm_transcriptomics"] == "X_pca_transcriptomics"
+    assert recorded["used_obsm_morphology"] == "X_pca_morphology"
     assert recorded["used_obsm_combined"] != recorded["used_obsm_transcriptomics"]
     assert recorded["n_cluster"] == 2
     assert recorded["refine_cluster"] is False
+    assert "X_pca_transcriptomics" not in adata.obsm
     np.testing.assert_array_equal(recorded["x_array"], adata.obs["array_row"])
     np.testing.assert_array_equal(recorded["y_array"], adata.obs["array_col"])
+
+
+@pytest.mark.asyncio
+async def test_identify_domains_aestetik_restores_canonical_input_keys(
+    minimal_spatial_adata, monkeypatch: pytest.MonkeyPatch
+):
+    adata = _aestetik_adata(minimal_spatial_adata)
+    n_obs = adata.n_obs
+    original_transcriptomics = np.full((n_obs, 2), 11.0)
+    original_morphology = np.full((n_obs, 2), 13.0)
+    custom_transcriptomics = np.full((n_obs, 3), 17.0)
+    custom_morphology = np.full((n_obs, 4), 19.0)
+    adata.obsm["X_pca_transcriptomics"] = original_transcriptomics.copy()
+    adata.obsm["X_pca_morphology"] = original_morphology.copy()
+    adata.obsm["custom_transcriptomics"] = custom_transcriptomics
+    adata.obsm["custom_morphology"] = custom_morphology
+
+    class _FakeAestetik:
+        def __init__(self, **kwargs):
+            assert kwargs["used_obsm_transcriptomics"] == "X_pca_transcriptomics"
+            assert kwargs["used_obsm_morphology"] == "X_pca_morphology"
+
+        def fit(self, X):
+            np.testing.assert_array_equal(
+                X.obsm["X_pca_transcriptomics"], custom_transcriptomics
+            )
+            np.testing.assert_array_equal(X.obsm["X_pca_morphology"], custom_morphology)
+            self.embedding_ = np.ones((X.n_obs, 2))
+            self.labels_ = np.zeros(X.n_obs, dtype=int)
+            return self
+
+    _install_fake_aestetik(monkeypatch, _FakeAestetik)
+
+    await sd._identify_domains_aestetik(
+        adata,
+        SpatialDomainParameters(
+            method="aestetik",
+            aestetik_transcriptomics_key="custom_transcriptomics",
+            aestetik_morphology_key="custom_morphology",
+        ),
+        DummyCtx(adata),
+    )
+
+    np.testing.assert_array_equal(
+        adata.obsm["X_pca_transcriptomics"], original_transcriptomics
+    )
+    np.testing.assert_array_equal(adata.obsm["X_pca_morphology"], original_morphology)
 
 
 @pytest.mark.asyncio
@@ -2030,6 +2110,27 @@ async def test_identify_domains_aestetik_rejects_non_finite_representation(
 
 
 @pytest.mark.asyncio
+async def test_identify_domains_aestetik_rejects_non_numeric_representation(
+    minimal_spatial_adata, monkeypatch: pytest.MonkeyPatch
+):
+    adata = _aestetik_adata(minimal_spatial_adata)
+    adata.obsm["X_pca_morphology"] = np.full((adata.n_obs, 2), "not-numeric")
+
+    class _FakeAestetik:
+        def __init__(self, **kwargs):
+            raise AssertionError("estimator must not be constructed")
+
+    _install_fake_aestetik(monkeypatch, _FakeAestetik)
+
+    with pytest.raises(DataNotFoundError, match="not a numeric morphology"):
+        await sd._identify_domains_aestetik(
+            adata,
+            SpatialDomainParameters(method="aestetik"),
+            DummyCtx(adata),
+        )
+
+
+@pytest.mark.asyncio
 async def test_identify_domains_aestetik_requires_lattice_coordinates(
     minimal_spatial_adata, monkeypatch: pytest.MonkeyPatch
 ):
@@ -2109,6 +2210,21 @@ async def test_identify_domains_aestetik_missing_estimator_is_reported(
     monkeypatch.setattr(sd, "require", _required_dependency)
 
     with pytest.raises(DependencyError, match="fit/predict API"):
+        await sd._identify_domains_aestetik(
+            adata,
+            SpatialDomainParameters(method="aestetik"),
+            DummyCtx(adata),
+        )
+
+
+@pytest.mark.asyncio
+async def test_identify_domains_aestetik_reports_python_314_incompatibility(
+    minimal_spatial_adata, monkeypatch: pytest.MonkeyPatch
+):
+    adata = _aestetik_adata(minimal_spatial_adata)
+    monkeypatch.setattr(sd.sys, "version_info", (3, 14, 0))
+
+    with pytest.raises(DependencyError, match="does not support Python 3.14"):
         await sd._identify_domains_aestetik(
             adata,
             SpatialDomainParameters(method="aestetik"),


### PR DESCRIPTION
Adds AESTETIK as an optional backend for `identify_spatial_domains`, implementing the contract agreed in #28. The data loader is untouched.

**Input contract.** `aestetik_morphology_key` defaults to `X_pca_morphology`; `aestetik_transcriptomics_key` defaults to `X_pca`, so it composes with `compute_embeddings`. The backend validates both precomputed numeric representations and requires discrete lattice coordinates from `x_array`/`y_array` or Visium `array_row`/`array_col`. Missing or invalid inputs raise actionable errors.

**Result consistency.** `labels_` and `embedding_` are published from the same fitted run, avoiding a second stochastic transform. Shared spatial refinement remains the single refinement stage.

**Dependency boundary.** `aestetik>=0.3.1,<0.4` is a dedicated optional extra with a `python_version < "3.14"` marker and is intentionally excluded from `[full]`.

**Maintainer hardening.** The integration now uses request-local canonical input aliases for an AESTETIK 0.3.x custom-key bug and restores any pre-existing keys after fitting. Lightning logging is disabled on a request-local estimator subclass with a temporary trainer root, so server runs do not leave `lightning_logs/` artifacts or change process-wide state. Returned embeddings and labels are checked for shape, numeric finiteness, and missing values. Parameter bounds, dependency metadata, method counts, and public documentation are covered by regression tests.

Verification: 1636 tests passed (4 intentionally deselected), MCP protocol-era tests passed, dependency checks passed, and a real MCP call on a 36-spot synthetic lattice completed with two balanced domains and no training artifacts. `black`, `isort`, and `ruff` are clean on `chatspatial/`.

Refs #28.